### PR TITLE
Fix issue where we were hashing a seed string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -160,7 +160,6 @@ const childSeedFromSeed = async config => {
 const childNodeFromSeed = async config => {
   const { seed, type, revision, ship, password } = config;
   const childSeed = await childSeedFromSeed({seed, type, revision, ship, password});
-  const childSeedBuffer = buf2hex(childSeed);
   return {
     meta: {
       type,
@@ -169,8 +168,8 @@ const childNodeFromSeed = async config => {
         ? ship
         : null
     },
-    seed: childSeedBuffer,
-    keys: await walletFromSeed(childSeedBuffer, password),
+    seed: buf2hex(childSeed),
+    keys: await walletFromSeed(childSeed, password),
   };
 };
 


### PR DESCRIPTION
> The first instance is in the  childNodeFromSeed  function. It returns the seed in a human readable hexadecimal format which we think is okay, but it also passes the childSeed to the  walletFromSeed  function as a hexadecimal string instead of a buffer, which is problematic because the  walletFromSeed  function will call hash on that string. This will work, but the result will not be the same as hashing the underlying seed directly. In other words, SHA-512(buffer) != SHA-512(buf2hex(buffer)).

This is that instance. Incorrect variable naming is no bueno! Pretty sure this fixes it.

Prior to making this change, one test failed. After making this change, two tests failed, because this changes the output to be more correct, which the tests don't yet account for.

(May or may not fix the tests myself, but putting this PR out so it can start being reviewed.