### PR TITLE
Check shard consistency before creating them.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "urbit-keygen",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7602,9 +7602,9 @@
       }
     },
     "urbit-ob": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/urbit-ob/-/urbit-ob-1.3.0.tgz",
-      "integrity": "sha512-yaM/Vy4HrJgcr0uomT5g9EiRocBFkHZ8SomN5nBZOLQFFO+4c7Z8Oy/DdrW+myWAFyNxWCeIH5HGQsrpGqTdrw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/urbit-ob/-/urbit-ob-1.4.1.tgz",
+      "integrity": "sha512-qDf7s4Z85mWpRLsSOsgNeVfHUnaKXb16ERjJL4DJ7cx3QALCRiQzFUVH3vN0dJkOt8TqOfG5sVFCPXE63oeoog==",
       "requires": {
         "babel-plugin-lodash": "^3.3.4",
         "bn.js": "^4.11.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbit-keygen",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Wrapper functions for key generation according to the Urbit hierarchical wallet design.",
   "main": "src/index.js",
   "scripts": {
@@ -25,7 +25,7 @@
     "bip32": "^1.0.2",
     "isomorphic-webcrypto": "^1.6.0",
     "lodash": "^4.17.11",
-    "urbit-ob": "^1.3.0",
+    "urbit-ob": "^1.4.1",
     "tweetnacl": "^1.0.0"
   },
   "devDependencies": {

--- a/tests/property.js
+++ b/tests/property.js
@@ -26,20 +26,6 @@ const buffer = jsc.nearray(jsc.uint8).smap(
 
 const patq = hexString.smap(ob.hex2patq, ob.patq2hex)
 
-removeLeadingZeroBytes = str =>
-  str.slice(0, 2) === '00'
-  ? removeLeadingZeroBytes(str.slice(2))
-  : str
-
-eqModLeadingZeroBytes = (s, t) =>
-  removeLeadingZeroBytes(s) === removeLeadingZeroBytes(t)
-
-eqPatq = (p, q) => {
-  phex = ob.patq2hex(p)
-  qhex = ob.patq2hex(q)
-  return eqModLeadingZeroBytes(phex, qhex)
-}
-
 describe('sharding', () => {
   it('hex2buf and buf2hex are inverses', () => {
     let iso0 = jsc.forall(hexString, hex =>
@@ -68,7 +54,7 @@ describe('sharding', () => {
   it('combinePatq . shardPatq ~ id', () => {
     let rel = jsc.forall(patq, pq => {
       let combined = _combinePatq(_shardPatq(pq))
-      return eqPatq(combined, pq)
+      return ob.eqPatq(combined, pq)
     })
 
     jsc.assert(rel, { tests: 250 })


### PR DESCRIPTION
To remove the possibility of any surprises in production (i.e., where it counts), this adds the sanity check that any subset of shards actually recombines as expected *prior* to returning the shards themselves.