### PR TITLE
Export shardPatq/combinePatq.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,4 @@
+# Changelog
+
+- 2.1.0 (2018-10-11)
+    * Export 'shardPatq' and 'combinePatq' functions.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbit-keygen",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Wrapper functions for key generation according to the Urbit hierarchical wallet design.",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -253,7 +253,7 @@ const urbitKeysFromSeed = (seed, password) => {
  * @param  {string}  ref a reference value for comparison
  * @param  {string => string => bool}  comp a comparison function
  * @param  {array of strings}  shards an array of shards
- * @return  {array of shards}  returns consistent shards
+ * @return  {bool}  true if shards consistent
  */
 const shardsConsistent = (combiner, ref, comp, shards) => {
   const set0 = shards.slice(0, 2);
@@ -537,8 +537,7 @@ const _shardBuffer = shardBuffer;
 const _combineBuffer = combineBuffer;
 const _shardHex = shardHex;
 const _combineHex = combineHex;
-const _shardPatq = shardPatq;
-const _combinePatq = combinePatq;
+const _shardsConsistent = shardsConsistent;
 
 module.exports = {
   argon2u,
@@ -548,6 +547,8 @@ module.exports = {
   walletFromSeed,
   urbitKeysFromSeed,
   shardWallet,
+  shardPatq,
+  combinePatq,
   _buf2hex,
   _hex2buf,
   _hash,
@@ -558,6 +559,5 @@ module.exports = {
   _combineBuffer,
   _shardHex,
   _combineHex,
-  _shardPatq,
-  _combinePatq
+  _shardsConsistent
 }

--- a/tests/test.js
+++ b/tests/test.js
@@ -6,14 +6,13 @@ import {
   walletFromSeed,
   urbitKeysFromSeed,
   shardWallet,
-  combine,
+  shardPatq,
+  combinePatq,
   _get,
   _buf2hex,
   _hex2buf,
   _shardHex,
   _combineHex,
-  _shardPatq,
-  _combinePatq,
   _shardBuffer,
   _combineBuffer
 } from '../src/index'
@@ -365,39 +364,39 @@ test('sharding internals: combineHex . shardHex ~ id', async () => {
 
 test('sharding internals: combinePatq . shardPatq ~ id', async () => {
   const original0 = '~dozset-ligtug-watlun-salwet-watsyr';
-  let shards = _shardPatq(original0);
+  let shards = shardPatq(original0);
   let slice0 = shards.slice(0, 2);
   let slice1 = shards.slice(1, 3);
   let slice2 = shards.slice(0, 1).concat(shards.slice(2, 3));
-  let reconstructed = _combinePatq(slice0)
+  let reconstructed = combinePatq(slice0)
   expect(reconstructed).toEqual(original0);
-  reconstructed = _combinePatq(slice1);
+  reconstructed = combinePatq(slice1);
   expect(reconstructed).toEqual(original0);
-  reconstructed = _combinePatq(slice2);
+  reconstructed = combinePatq(slice2);
   expect(reconstructed).toEqual(original0);
 
   const original1 = '~tolsup-lacrym-firryl-salnux-silrud-daplec-mirwes-lidrum-fogfed-bacwyt-winpet-ritler-pittud-billyd-batmel-ricdem';
-  shards = _shardPatq(original1);
+  shards = shardPatq(original1);
   slice0 = shards.slice(0, 2);
   slice1 = shards.slice(1, 3);
   slice2 = shards.slice(0, 1).concat(shards.slice(2, 3));
-  reconstructed = _combinePatq(slice0)
+  reconstructed = combinePatq(slice0)
   expect(reconstructed).toEqual(original1);
-  reconstructed = _combinePatq(slice1);
+  reconstructed = combinePatq(slice1);
   expect(reconstructed).toEqual(original1);
-  reconstructed = _combinePatq(slice2);
+  reconstructed = combinePatq(slice2);
   expect(reconstructed).toEqual(original1);
 
   const original2 = '~dozbud-doslyt-pinmer-fopsyd-noltev-tabsym-widsur-biclur-tolfeb-nortus-motdus-tilsev-picwyl-sipwyd-mitdes-watsyn-bacrup';
-  shards = _shardPatq(original2);
+  shards = shardPatq(original2);
   slice0 = shards.slice(0, 2);
   slice1 = shards.slice(1, 3);
   slice2 = shards.slice(0, 1).concat(shards.slice(2, 3));
-  reconstructed = _combinePatq(slice0)
+  reconstructed = combinePatq(slice0)
   expect(reconstructed).toEqual(original2);
-  reconstructed = _combinePatq(slice1);
+  reconstructed = combinePatq(slice1);
   expect(reconstructed).toEqual(original2);
-  reconstructed = _combinePatq(slice2);
+  reconstructed = combinePatq(slice2);
   expect(reconstructed).toEqual(original2);
 
 });
@@ -418,11 +417,11 @@ test('sharded wallet from seed', async () => {
   let slice0 = sharded.slice(0, 2);
   let slice1 = sharded.slice(1, 3);
   let slice2 = sharded.slice(0, 1).concat(sharded.slice(2, 3));
-  let reconstructed = _combinePatq(slice0);
+  let reconstructed = combinePatq(slice0);
   expect(reconstructed).toEqual(ticket);
-  reconstructed = _combinePatq(slice1);
+  reconstructed = combinePatq(slice1);
   expect(reconstructed).toEqual(ticket);
-  reconstructed = _combinePatq(slice2);
+  reconstructed = combinePatq(slice2);
   expect(reconstructed).toEqual(ticket);
 
   ticket = '~norlun-sidruc-tarlun-timpel-malmyn-watmeb-holdut-davwex-balwet-divwen-holwet-tanwet-mallun-timpel-malmyn-watmeb-holdut-picruc-mallun-botwet-dolpel-padwet';
@@ -439,11 +438,11 @@ test('sharded wallet from seed', async () => {
   slice0 = sharded.slice(0, 2);
   slice1 = sharded.slice(1, 3);
   slice2 = sharded.slice(0, 1).concat(sharded.slice(2, 3));
-  reconstructed = _combinePatq(slice0);
+  reconstructed = combinePatq(slice0);
   expect(reconstructed).toEqual(ticket);
-  reconstructed = _combinePatq(slice1);
+  reconstructed = combinePatq(slice1);
   expect(reconstructed).toEqual(ticket);
-  reconstructed = _combinePatq(slice2);
+  reconstructed = combinePatq(slice2);
   expect(reconstructed).toEqual(ticket);
 });
 


### PR DESCRIPTION
These guys are useful downstream, e.g. in the wallet generator apps and probably in Bridge.  We might eventually want to move them into a general Urbit utils library.