### PR TITLE
Prune dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "urbit-key-generation",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -608,22 +608,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "coinstring": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/coinstring/-/coinstring-2.3.0.tgz",
-      "integrity": "sha1-zbYzY6lhUCQEolr7gsLibV/2J6Q=",
-      "requires": {
-        "bs58": "^2.0.1",
-        "create-hash": "^1.1.1"
-      },
-      "dependencies": {
-        "bs58": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/bs58/-/bs58-2.0.1.tgz",
-          "integrity": "sha1-VZCNWPGYKrogCPob7Y+RmYopv40="
-        }
-      }
-    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -887,6 +871,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.0.0.tgz",
       "integrity": "sha512-E3yKUyl0Fs95nvTFQZe/ZSNcofhDzUsDlA5y2uoRmf1+Ec7gpGhNCsgKkZBRh7Br5op8mJcYF/jFbmjj909+nQ==",
+      "dev": true,
       "requires": {
         "bn.js": "^4.11.0",
         "create-hash": "^1.1.2",
@@ -901,6 +886,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
       "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+      "dev": true,
       "requires": {
         "is-hex-prefixed": "1.0.0",
         "strip-hex-prefix": "1.0.0"
@@ -1021,16 +1007,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "hdkey": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/hdkey/-/hdkey-1.1.0.tgz",
-      "integrity": "sha512-E7aU8pNlWUJbXGjTz/+lKf1LkMcA3hUrC5ZleeizrmLSd++kvf8mSOe3q8CmBDA9j4hdfXO5iY6hGiTUCOV2jQ==",
-      "requires": {
-        "coinstring": "^2.0.0",
-        "safe-buffer": "^5.1.1",
-        "secp256k1": "^3.0.1"
-      }
-    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -1116,7 +1092,8 @@
     "is-hex-prefixed": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
+      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
+      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -2781,6 +2758,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.1.0.tgz",
       "integrity": "sha512-93U7IKH5j7nmXFVg19MeNBGzQW5uXW1pmCuKY8veeKIhYTE32C2d0mOegfiIAfXcHOKJjjPlJisn8iHDF5AezA==",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.1.1"
       }
@@ -2909,6 +2887,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
       "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
+      "dev": true,
       "requires": {
         "is-hex-prefixed": "1.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -278,6 +278,14 @@
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
       "integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
     },
+    "base-x": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.5.tgz",
+      "integrity": "sha512-C3picSgzPSLE+jW3tcBzJoGwitOtazb5B+5YmAxZm2ybmTi9LNgAtDO/jjVEBZwHoXmDBZ9m/IELj3elJVRBcA==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
@@ -292,6 +300,19 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
       "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+    },
+    "bip32": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-1.0.2.tgz",
+      "integrity": "sha512-kedLYj8yvYzND+EfzeoMSlGiN7ImiRBF/MClJSZPkMfcU+OQO7ZpL5L/Yg+TunebBZIHhunstiQF//KLKSF5rg==",
+      "requires": {
+        "bs58check": "^2.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "tiny-secp256k1": "^1.0.0",
+        "typeforce": "^1.11.5",
+        "wif": "^2.0.6"
+      }
     },
     "bip39": {
       "version": "2.5.0",
@@ -494,6 +515,24 @@
       "dev": true,
       "requires": {
         "pako": "~1.0.5"
+      }
+    },
+    "bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "requires": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "requires": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
       }
     },
     "buffer": {
@@ -2931,6 +2970,18 @@
         "process": "~0.11.0"
       }
     },
+    "tiny-secp256k1": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.0.1.tgz",
+      "integrity": "sha512-Wz2kMPWtCI5XBftFeF3bUL8uz2+VlasniKwOkRPjvL7h1QVd9rbhrve/HWUu747kJKzVf1XHonzcdM4Ut8fvww==",
+      "requires": {
+        "bindings": "^1.3.0",
+        "bn.js": "^4.11.8",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.4.0",
+        "nan": "^2.10.0"
+      }
+    },
     "to-arraybuffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
@@ -2977,6 +3028,11 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "typeforce": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.16.0.tgz",
+      "integrity": "sha512-V60F7OHPH7vPlgIU73vYyeebKxWjQqCTlge+MvKlVn09PIhCOi/ZotowYdgREHB5S1dyHOr906ui6NheYXjlVQ=="
     },
     "typify-parser": {
       "version": "1.1.0",
@@ -3065,6 +3121,14 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/webcrypto-shim/-/webcrypto-shim-0.1.4.tgz",
       "integrity": "sha512-I2lnL+K2oPNE9ryVHwo42oDnt8XQ9E1KKMGCmcT7OXaAKPmUeCi/G0nUgLR6M6Ztj05ZCxLMGf5bXNaSo+wURg=="
+    },
+    "wif": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
+      "requires": {
+        "bs58check": "<3.0.0"
+      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbit-key-generation",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Key derivation and HD wallet generation functions for Urbit.",
   "main": "src/index.js",
   "browser": {
@@ -25,9 +25,9 @@
   "homepage": "https://github.com/urbit/keygen-js#readme",
   "dependencies": {
     "argon2-wasm": "github:urbit/argon2-wasm.git#00c29a4",
+    "bip32": "^1.0.2",
     "bip39": "^2.5.0",
     "ethereumjs-util": "^6.0.0",
-    "hdkey": "^1.1.0",
     "isomorphic-webcrypto": "^1.6.0",
     "lodash": "^4.17.11",
     "tweetnacl": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -27,15 +27,17 @@
     "argon2-wasm": "github:urbit/argon2-wasm.git#00c29a4",
     "bip32": "^1.0.2",
     "bip39": "^2.5.0",
-    "ethereumjs-util": "^6.0.0",
     "isomorphic-webcrypto": "^1.6.0",
+    "keccak": "^1.4.0",
     "lodash": "^4.17.11",
+    "secp256k1": "^3.5.2",
     "tweetnacl": "^1.0.0",
     "urbit-ob": "^3.0.0"
   },
   "devDependencies": {
     "browserify": "^16.2.3",
     "chai": "^4.2.0",
+    "ethereumjs-util": "^6.0.0",
     "fs-extra": "^7.0.0",
     "jsverify": "^0.8.3",
     "mocha": "^5.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 const argon2 = require('argon2-wasm')
+const bip32 = require('bip32')
 const bip39 = require('bip39')
 const crypto = require('isomorphic-webcrypto')
 const util = require('ethereumjs-util')
-const hdkey = require('hdkey')
 const lodash = require('lodash')
 const nacl = require('tweetnacl')
 const ob = require('urbit-ob')
@@ -142,9 +142,8 @@ const childNodeFromSeed = async config => {
  */
 const bip32NodeFromSeed = (mnemonic, password) => {
   const seed = bip39.mnemonicToSeed(mnemonic, password)
-  const hd = hdkey.fromMasterSeed(seed)
-  const path = "m/44'/60'/0'/0/0"
-  const wallet = hd.derive(path)
+  const hd = bip32.fromSeed(seed)
+  const wallet = hd.derivePath("m/44'/60'/0'/0/0")
 
   const publicKey = buf2hex(wallet.publicKey)
   const privateKey = buf2hex(wallet.privateKey)

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,11 @@ const argon2 = require('argon2-wasm')
 const bip32 = require('bip32')
 const bip39 = require('bip39')
 const crypto = require('isomorphic-webcrypto')
-const util = require('ethereumjs-util')
+const keccak = require('keccak')
 const lodash = require('lodash')
 const nacl = require('tweetnacl')
 const ob = require('urbit-ob')
+const secp256k1 = require('secp256k1')
 
 const CHILD_SEED_TYPES = {
   OWNERSHIP: 'ownership',
@@ -14,6 +15,54 @@ const CHILD_SEED_TYPES = {
   VOTING: 'voting',
   MANAGEMENT: 'management',
   NETWORK: 'network'
+}
+
+/**
+ * Add a hex prefix to a string, if one isn't already present.
+ *
+ * @param  {String}  hex
+ * @return  {String}
+ */
+addHexPrefix = hex =>
+  hex.slice(0, 2) === '0x'
+  ? hex
+  : '0x' + hex
+
+/**
+ * Strip a hex prefix from a string, if it's present.
+ *
+ * @param  {String}  hex
+ * @return  {String}
+ */
+stripHexPrefix = hex =>
+  hex.slice(0, 2) === '0x'
+  ? hex.slice(2)
+  : hex
+
+/**
+ * Keccak-256 hash function.
+ *
+ * @param  {String}  str
+ * @return  {String}
+ */
+const keccak256 = str =>
+  keccak('keccak256').update(str).digest()
+
+/**
+ * Convert an Ethereum address to a checksummed Ethereum address.
+ *
+ * @param  {String}  address an Ethereum address
+ * @return  {String}  checksummed address
+ */
+toChecksumAddress = (address) => {
+  const addr = stripHexPrefix(address).toLowerCase()
+  const hash = keccak256(addr).toString('hex')
+
+  return lodash.reduce(addr, (acc, char, idx) =>
+    parseInt(hash[idx], 16) >= 8
+      ? acc + char.toUpperCase()
+      : acc + char,
+    '0x')
 }
 
 /**
@@ -198,13 +247,14 @@ const urbitKeysFromSeed = seed => {
  */
 const addressFromSecp256k1Public = pub => {
   const compressed = false
-  const uncompressed = util.secp256k1.publicKeyConvert(
+  const uncompressed = secp256k1.publicKeyConvert(
     Buffer.from(pub, 'hex'),
     compressed
   )
-  const hashed = util.keccak256(uncompressed.slice(1)) // chop parity byte
-  const addr = util.addHexPrefix(hashed.slice(-20).toString('hex'))
-  return util.toChecksumAddress(addr)
+  const chopped = uncompressed.slice(1) // chop parity byte
+  const hashed = keccak256(chopped)
+  const addr = addHexPrefix(hashed.slice(-20).toString('hex'))
+  return toChecksumAddress(addr)
 }
 
 
@@ -215,7 +265,7 @@ const addressFromSecp256k1Public = pub => {
  * @return  {String}  the corresponding Ethereum address
  */
 const addressFromSecp256k1Private = priv => {
-  const pub = util.secp256k1.publicKeyCreate(Buffer.from(priv, 'hex'))
+  const pub = secp256k1.publicKeyCreate(Buffer.from(priv, 'hex'))
   return addressFromSecp256k1Public(pub)
 }
 
@@ -365,5 +415,9 @@ module.exports = {
 
   _isGalaxy: isGalaxy,
   _sha256: sha256,
-  _nodeMetadata: nodeMetadata
+  _keccak256: keccak256,
+  _nodeMetadata: nodeMetadata,
+  _toChecksumAddress: toChecksumAddress,
+  _addHexPrefix: addHexPrefix,
+  _stripHexPrefix: stripHexPrefix
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
+const bip32 = require('bip32')
 const bip39 = require('bip39')
 const { expect } = require('chai')
 const fs = require('fs-extra')
-const hdkey = require('hdkey')
 const jsc = require('jsverify')
 const lodash = require('lodash')
 const ob = require('urbit-ob')
@@ -200,9 +200,9 @@ describe('bip32NodeFromSeed', () => {
 
     let prop = jsc.forall(mnemonic, mnem => {
       let seed = bip39.mnemonicToSeed(mnem)
-      let hd = hdkey.fromMasterSeed(seed)
-      let wallet0 = hd.derive(VALID_PATH)
-      let wallet1 = hd.derive(INVALID_PATH)
+      let hd = bip32.fromSeed(seed)
+      let wallet0 = hd.derivePath(VALID_PATH)
+      let wallet1 = hd.derivePath(INVALID_PATH)
 
       let node = kg.bip32NodeFromSeed(mnem)
 

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,7 @@ const fs = require('fs-extra')
 const jsc = require('jsverify')
 const lodash = require('lodash')
 const ob = require('urbit-ob')
+const util = require('ethereumjs-util')
 
 const kg = require('../src')
 
@@ -21,6 +22,27 @@ const replicate = (n, g) => jsc.tuple(new Array(n).fill(g))
 const seedBuffer256 = replicate(32, jsc.uint8)
 
 // tests
+
+describe('toChecksumAddress', () => {
+  it('matches a reference implementation', () => {
+    let prop = jsc.forall(seedBuffer256, buf => {
+      let hashed = kg._keccak256(buf.toString('hex'))
+      let addr = kg._addHexPrefix(hashed.slice(-20).toString('hex'))
+      return util.toChecksumAddress(addr) === kg._toChecksumAddress(addr)
+    })
+
+    jsc.assert(prop)
+  })
+})
+
+describe('hex prefix utils', () => {
+  it('work as expected', () => {
+    expect(kg._addHexPrefix('0102')).to.equal('0x0102')
+    expect(kg._addHexPrefix('0x0102')).to.equal('0x0102')
+    expect(kg._stripHexPrefix('0x0102')).to.equal('0102')
+    expect(kg._stripHexPrefix('0102')).to.equal('0102')
+  })
+})
 
 describe('isGalaxy', () => {
   const galaxies = jsc.integer(0, 255)

--- a/test/test.js
+++ b/test/test.js
@@ -208,11 +208,11 @@ describe('childSeedFromSeed', () => {
 })
 
 describe('bip32NodeFromSeed', () => {
-  const mnemonicGenerator = _ => bip39.generateMnemonic()
-  const mnemonic = jsc.nonshrink({
-    generator: mnemonicGenerator,
-    show: (a) => a
-  })
+
+  const mnemonic = replicate(16, jsc.uint8).smap(
+    bip39.entropyToMnemonic,
+    bip39.mnemonicToEntropy
+  )
 
   const VALID_PATH = "m/44'/60'/0'/0/0"
   const INVALID_PATH = "m/44'/60/0'/0/0"


### PR DESCRIPTION
Resolves #39.

This mainly just replaces the unnecessary and bloated-feeling `ethereumjs-util` with the specific things we need from it: `keccak` and `secp256k1`.  Additionally it feels better to swap the `hdkey` dependency for the more-standard `bip32` (which we used previously).

Surprisingly I can't find a better single alternative to replace what we currently use `isomorphic-webcrypto` (SHA-256) and `tweetnacl` (SHA-512, Ed25519) for.  `tweetnacl`, unlike plain-old nacl, doesn't implement a SHA-256 function.  Meanwhile, `isomorphic-webcrypto` exports both SHA-256 and SHA-512, but doesn't implement Ed25519.

I also checked `sjcl`, the Stanford Javascript Crypto Library, which implements SHA-256 and Ed25519.  But that inexplicably doesn't export SHA-512, even though there's an implementation in the library itself.  So, I guess we'll stick with two 'comprehensive' crypto dependencies for the time being.