### PR TITLE
Bugfix: optional password for BIP39.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+- 0.9.3 (2018-11-07)
+    * Bugfix, make sure optional password is used when deriving seeds from
+      BIP39 mnemonics when generating network keys.
+
 - 0.9.2 (2018-11-05)
     * Bugfix, add missing 'const' to utility function declarations.
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -58122,7 +58122,7 @@ const generateWallet = async config => {
 
   if (boot === true) {
     let seed = await childSeedFromSeed({
-      seed: bip39.mnemonicToSeed(management.seed),
+      seed: bip39.mnemonicToSeed(management.seed, password),
       type: CHILD_SEED_TYPES.NETWORK,
       ship: ship,
       revision: revision

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbit-key-generation",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Key derivation and HD wallet generation functions for Urbit.",
   "main": "src/index.js",
   "browser": {

--- a/src/index.js
+++ b/src/index.js
@@ -376,7 +376,7 @@ const generateWallet = async config => {
 
   if (boot === true) {
     let seed = await childSeedFromSeed({
-      seed: bip39.mnemonicToSeed(management.seed),
+      seed: bip39.mnemonicToSeed(management.seed, password),
       type: CHILD_SEED_TYPES.NETWORK,
       ship: ship,
       revision: revision


### PR DESCRIPTION
The optional password used when deriving seeds from BIP39 mnemonics was not being used when deriving network keys.

* Patch version bump (0.9.2 -> 0.9.3).