### PR TITLE
Add support for mechanically combining shards.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+- 0.10.0 (2018-11-10)
+    * Add a 'combine' function for recombining shards.
+
 - 0.9.3 (2018-11-07)
     * Bugfix, make sure optional password is used when deriving seeds from
       BIP39 mnemonics when generating network keys.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "urbit-key-generation",
-  "version": "0.9.1",
+  "version": "0.9.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3049,9 +3049,9 @@
       "integrity": "sha1-NkIA1fE2RsqLzURJAnEzVhR5IwA="
     },
     "urbit-ob": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/urbit-ob/-/urbit-ob-3.0.0.tgz",
-      "integrity": "sha512-XluVJct8PAF04O+bo5n9fDb8+eiNeBkLiC/5EAl1xV0NBJd0T9IM7LumU/PEU5qI6XyWPwz4lNe5cWbT10DfzQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/urbit-ob/-/urbit-ob-3.0.1.tgz",
+      "integrity": "sha512-4sO7mdNBvryMTLrY1tIiT8oXId5+uiJqo5VWXBcL4RcAysecv7pZI65gSE8r8Cxz18P2EUZ3VZnzuyqOP12y0w==",
       "requires": {
         "bn.js": "^4.11.8",
         "lodash": "^4.17.11"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbit-key-generation",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "description": "Key derivation and HD wallet generation functions for Urbit.",
   "main": "src/index.js",
   "browser": {
@@ -32,7 +32,7 @@
     "lodash": "^4.17.11",
     "secp256k1": "^3.5.2",
     "tweetnacl": "^1.0.0",
-    "urbit-ob": "^3.0.0"
+    "urbit-ob": "^3.0.1"
   },
   "devDependencies": {
     "browserify": "^16.2.3",

--- a/test/test.js
+++ b/test/test.js
@@ -21,6 +21,11 @@ const replicate = (n, g) => jsc.tuple(new Array(n).fill(g))
 
 const seedBuffer256 = replicate(32, jsc.uint8)
 
+const buffer384 = replicate(48, jsc.uint8).smap(
+  arr => Buffer.from(arr),
+  buf => Array.from(buf)
+)
+
 // tests
 
 describe('toChecksumAddress', () => {
@@ -405,6 +410,25 @@ describe('shard', () => {
   it('shards 384-bit tickets', () => {
     let ticket = '~wacfus-dabpex-danted-mosfep-pasrud-lavmer-nodtex-taslus-pactyp-milpub-pildeg-fornev-ralmed-dinfeb-fopbyr-sanbet-sovmyl-dozsut-mogsyx-mapwyc-sorrup-ricnec-marnys-lignex'
     expect(kg.shard(ticket)).to.have.lengthOf(3)
+  })
+
+  it('produces valid shards', () => {
+    let prop = jsc.forall(buffer384, buf => {
+      let ticket = ob.hex2patq(buf.toString('hex'))
+      let shards = kg.shard(ticket)
+
+      return (
+        kg.combine([shards[0], shards[1], undefined]) === ticket &&
+        kg.combine([shards[0], undefined, shards[2]]) === ticket &&
+        kg.combine([undefined, shards[1], shards[2]]) === ticket
+      )
+    })
+
+    jsc.assert(prop)
+  })
+
+  it('throws when insufficient shards', () => {
+    expect(() => kg.combine([undefined, undefined, undefined])).to.throw()
   })
 })
 


### PR DESCRIPTION
(Resolves #46)

Adds a 'combine' function for combining shards that have been provided in an array in the correct order.  Also, 'shard' now guarantees that shards can be recombined to match the original ticket before returning them at all.